### PR TITLE
doc: use a list for html_sidebars

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,10 +98,8 @@ html_theme = 'sphinxdoc'
 
 # html_index = 'index.html'
 html_sidebars = {
-    'index': 'indexsidebar.html',
+    'index': ['indexsidebar.html'],
 }
-#                 'basics': 'indexsidebar.html',
-# }
 # html_additional_pages = {'index': 'index.html'}
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Sphinx 1.7 deprecated the use of a single string in `html_sidebars`, and Sphinx 2.0 has dropped support for this altogether.