### PR TITLE
Fixed testing against Pytest 5.1

### DIFF
--- a/testing/test_gateway.py
+++ b/testing/test_gateway.py
@@ -36,10 +36,10 @@ def test_deprecation(recwarn, monkeypatch):
     execnet.PopenGateway().exit()
     assert recwarn.pop(DeprecationWarning)
     monkeypatch.setattr(socket, "socket", fails)
-    py.test.raises(Exception, 'execnet.SocketGateway("localhost", 8811)')
+    py.test.raises(Exception, execnet.SocketGateway, "localhost", 8811)
     assert recwarn.pop(DeprecationWarning)
     monkeypatch.setattr(subprocess, "Popen", fails)
-    py.test.raises(Exception, 'execnet.SshGateway("not-existing")')
+    py.test.raises(Exception, execnet.SshGateway, "not-existing")
     assert recwarn.pop(DeprecationWarning)
 
 


### PR DESCRIPTION
As of Pytest 5.1.0
> pytest.raises and pytest.warns no longer support strings as the
> second argument

https://docs.pytest.org/en/latest/changelog.html#removals

Fixes: https://github.com/pytest-dev/execnet/issues/106