### PR TITLE
re-introduce linecache usage again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,10 @@
-1.7.0 (08-08-2019)
+1.7.1 (2019-08-28)
+------------------
+
+* `#108 <https://github.com/pytest-dev/execnet/issues/108>`__: Revert ``linecache`` optimization introduced in ``1.7.0`` which
+  broke remote execution.
+
+1.7.0 (2019-08-08)
 ------------------
 
 * `#102 <https://github.com/pytest-dev/execnet/pull/102>`__: Show paths in stack traces

--- a/execnet/gateway.py
+++ b/execnet/gateway.py
@@ -4,6 +4,7 @@ gateway code for initiating popen, socket and ssh connections.
 (c) 2004-2013, Holger Krekel and others
 """
 import inspect
+import linecache
 import os
 import sys
 import textwrap
@@ -111,10 +112,8 @@ class Gateway(gateway_base.BaseGateway):
         file_name = None
         if isinstance(source, types.ModuleType):
             file_name = inspect.getsourcefile(source)
-            if not file_name:
-                source = inspect.getsource(source)
-            else:
-                source = None
+            linecache.updatecache(file_name)
+            source = inspect.getsource(source)
         elif isinstance(source, types.FunctionType):
             call_name = source.__name__
             file_name = inspect.getsourcefile(source)

--- a/execnet/gateway_base.py
+++ b/execnet/gateway_base.py
@@ -14,7 +14,6 @@ NOTE: aims to be compatible to Python 2.5-3.X, Jython and IronPython
 """
 from __future__ import with_statement
 
-import linecache
 import os
 import struct
 import sys
@@ -1077,9 +1076,6 @@ class SlaveGateway(BaseGateway):
                         name = name.encode("ascii")
                     newkwargs[name] = value
                 kwargs = newkwargs
-            if source is None:
-                assert file_name, file_name
-                source = "".join(linecache.updatecache(file_name))
             loc = {"channel": channel, "__name__": "__channelexec__"}
             self._trace("execution starts[%s]: %s" % (channel.id, repr(source)[:50]))
             channel._executing = True


### PR DESCRIPTION
This removes the if/else case when the file_name is not present, and
relies once again on linecache, fixing a problem where `source` would
always be set to `None` in remote modules

Fixes issue #108 