### PR TITLE
Replace "slave" terminology

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -343,7 +343,7 @@
   to let KeyboardInterrupts pass through.
 
 - EXECNET_DEBUG=2 will cause tracing to go to stderr,
-  which with popen slave gateways will relay back
+  which with popen worker gateways will relay back
   tracing to the instantiator process.
 
 

--- a/doc/basics.rst
+++ b/doc/basics.rst
@@ -221,7 +221,7 @@ By setting the environment variable ``EXECNET_DEBUG`` you can
 configure a tracing mechanism:
 
 :EXECNET_DEBUG=1:  write per-process trace-files to ``execnet-debug-PID``
-:EXECNET_DEBUG=2:  perform tracing to stderr (popen-gateway slaves will send this to their instantiator)
+:EXECNET_DEBUG=2:  perform tracing to stderr (popen-gateway workers will send this to their instantiator)
 
 
 .. _`dumps/loads`:

--- a/doc/example/test_debug.rst
+++ b/doc/example/test_debug.rst
@@ -6,7 +6,7 @@ By setting the environment variable ``EXECNET_DEBUG`` you can
 configure the execnet tracing mechanism:
 
 :EXECNET_DEBUG=1:  write per-process trace-files to ``${TEMPROOT}/execnet-debug-PID``
-:EXECNET_DEBUG=2:  perform tracing to stderr (popen-gateway slaves will send this to their instantiator)
+:EXECNET_DEBUG=2:  perform tracing to stderr (popen-gateway workers will send this to their instantiator)
 
 Here is a simple example to see what goes on with a simple execution::
 
@@ -18,13 +18,13 @@ which will show PID-prefixed trace entries::
 
     [2326] gw0 starting to receive
     [2326] gw0 sent <Message.CHANNEL_EXEC channelid=1 '42'>
-    [2327] creating slavegateway on <execnet.gateway_base.Popen2IO instance at 0x9f1c20c>
-    [2327] gw0-slave starting to receive
-    [2327] gw0-slave received <Message.CHANNEL_EXEC channelid=1 '42'>
-    [2327] gw0-slave execution starts[1]: '42'
-    [2327] gw0-slave execution finished
-    [2327] gw0-slave sent <Message.CHANNEL_CLOSE channelid=1 ''>
-    [2327] gw0-slave 1 sent channel close message
+    [2327] creating workergateway on <execnet.gateway_base.Popen2IO instance at 0x9f1c20c>
+    [2327] gw0-worker starting to receive
+    [2327] gw0-worker received <Message.CHANNEL_EXEC channelid=1 '42'>
+    [2327] gw0-worker execution starts[1]: '42'
+    [2327] gw0-worker execution finished
+    [2327] gw0-worker sent <Message.CHANNEL_CLOSE channelid=1 ''>
+    [2327] gw0-worker 1 sent channel close message
     [2326] gw0 received <Message.CHANNEL_CLOSE channelid=1 ''>
     [2326] gw0 1 channel.__del__
     [2326] === atexit cleanup <Group ['gw0']> ===
@@ -32,12 +32,12 @@ which will show PID-prefixed trace entries::
     [2326] gw0 --> sending GATEWAY_TERMINATE
     [2326] gw0 sent <Message.GATEWAY_TERMINATE channelid=0 ''>
     [2326] gw0 joining receiver thread
-    [2327] gw0-slave received <Message.GATEWAY_TERMINATE channelid=0 ''>
-    [2327] gw0-slave putting None to execqueue
-    [2327] gw0-slave io.close_read()
-    [2327] gw0-slave leaving <Thread(receiver, started daemon -1220277392)>
-    [2327] gw0-slave 1 channel.__del__
-    [2327] gw0-slave io.close_write()
-    [2327] gw0-slave slavegateway.serve finished
-    [2327] gw0-slave gateway.join() called while receiverthread already finished
+    [2327] gw0-worker received <Message.GATEWAY_TERMINATE channelid=0 ''>
+    [2327] gw0-worker putting None to execqueue
+    [2327] gw0-worker io.close_read()
+    [2327] gw0-worker leaving <Thread(receiver, started daemon -1220277392)>
+    [2327] gw0-worker 1 channel.__del__
+    [2327] gw0-worker io.close_write()
+    [2327] gw0-worker workergateway.serve finished
+    [2327] gw0-worker gateway.join() called while receiverthread already finished
     [2326] gw0 leaving <Thread(receiver, started daemon -1221223568)>

--- a/doc/example/test_proxy.rst
+++ b/doc/example/test_proxy.rst
@@ -1,15 +1,14 @@
-Managing Proxyed gateways
+Managing Proxied gateways
 ==========================
 
 Simple Proxying
 ----------------
 
 Using the via arg of specs we can create a gateway
-whose io os created on a remote gateway and
-proxyed to the master.
+whose io is created on a remote gateway and proxied to the master.
 
 The simlest use case, is where one creates one master process
-and uses it to controll new slaves and their environment
+and uses it to control new workers and their environment
 
 ::
 
@@ -19,8 +18,8 @@ and uses it to controll new slaves and their environment
     >>> master = group.makegateway('popen//id=master')
     >>> master
     <Gateway id='master' receive-live, thread model, 0 active channels>
-    >>> slave = group.makegateway()
-    >>> slave
+    >>> worker = group.makegateway()
+    >>> worker
     <Gateway id='gw0' receive-live, thread model, 0 active channels>
     >>> group
     <Group ['master', 'gw0']>

--- a/execnet/gateway_base.py
+++ b/execnet/gateway_base.py
@@ -936,7 +936,7 @@ class ChannelFileRead(ChannelFile):
 class BaseGateway(object):
     exc_info = sys.exc_info
     _sysex = sysex
-    id = "<slave>"
+    id = "<worker>"
 
     def __init__(self, io, id, _startcount=2):
         self.execmodel = io.execmodel
@@ -1020,7 +1020,7 @@ class BaseGateway(object):
         self._receivepool.waitall()
 
 
-class SlaveGateway(BaseGateway):
+class WorkerGateway(BaseGateway):
     def _local_schedulexec(self, channel, sourcetask):
         sourcetask = loads_internal(sourcetask)
         self._execpool.spawn(self.executetask, (channel, sourcetask))
@@ -1061,7 +1061,7 @@ class SlaveGateway(BaseGateway):
             trace("joining receiver thread")
             self.join()
         except KeyboardInterrupt:
-            # in the slave we can't really do anything sensible
+            # in the worker we can't really do anything sensible
             trace("swallowing keyboardinterrupt, serve finished")
 
     def executetask(self, item):
@@ -1550,5 +1550,5 @@ def init_popen_io(execmodel):
 
 
 def serve(io, id):
-    trace("creating slavegateway on {!r}".format(io))
-    SlaveGateway(io=io, id=id, _startcount=2).serve()
+    trace("creating workergateway on {!r}".format(io))
+    WorkerGateway(io=io, id=id, _startcount=2).serve()

--- a/execnet/gateway_bootstrap.py
+++ b/execnet/gateway_bootstrap.py
@@ -29,7 +29,7 @@ def bootstrap_import(io, spec):
         "sys.stdout.write('1')",
         "sys.stdout.flush()",
         "execmodel = get_execmodel(%r)" % spec.execmodel,
-        "serve(init_popen_io(execmodel), id='%s-slave')" % spec.id,
+        "serve(init_popen_io(execmodel), id='%s-worker')" % spec.id,
     )
     s = io.read(1)
     assert s == "1".encode("ascii"), repr(s)
@@ -43,7 +43,7 @@ def bootstrap_exec(io, spec):
             "execmodel = get_execmodel(%r)" % spec.execmodel,
             "io = init_popen_io(execmodel)",
             "io.write('1'.encode('ascii'))",
-            "serve(io, id='%s-slave')" % spec.id,
+            "serve(io, id='%s-worker')" % spec.id,
         )
         s = io.read(1)
         assert s == "1".encode("ascii")
@@ -67,7 +67,7 @@ def bootstrap_socket(io, id):
         "   execmodel = get_execmodel('thread')",
         "io = SocketIO(clientsock, execmodel)",
         "io.write('1'.encode('ascii'))",
-        "serve(io, id='%s-slave')" % id,
+        "serve(io, id='%s-worker')" % id,
     )
     s = io.read(1)
     assert s == "1".encode("ascii")

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -282,7 +282,7 @@ class PseudoChannel:
 def test_exectask(execmodel):
     io = py.io.BytesIO()
     io.execmodel = execmodel
-    gw = gateway_base.SlaveGateway(io, id="something")
+    gw = gateway_base.WorkerGateway(io, id="something")
     ch = PseudoChannel()
     gw.executetask((ch, ("raise ValueError()", None, {})))
     assert "ValueError" in str(ch._closed[0])

--- a/testing/test_gateway.py
+++ b/testing/test_gateway.py
@@ -470,14 +470,14 @@ class TestTracing:
         fn = gw.remote_exec(
             "import execnet;channel.send(execnet.gateway_base.fn)"
         ).receive()
-        slavefile = py.path.local(fn)
-        assert slavefile.check()
-        slave_line = "creating slavegateway"
-        for line in slavefile.readlines():
-            if slave_line in line:
+        workerfile = py.path.local(fn)
+        assert workerfile.check()
+        worker_line = "creating workergateway"
+        for line in workerfile.readlines():
+            if worker_line in line:
                 break
         else:
-            py.test.fail("did not find {!r} in tracefile".format(slave_line))
+            py.test.fail("did not find {!r} in tracefile".format(worker_line))
         gw.exit()
 
     @skip_win_pypy
@@ -487,8 +487,8 @@ class TestTracing:
         gw = makegateway("popen")
         pid = gw.remote_exec("import os ; channel.send(os.getpid())").receive()
         out, err = capfd.readouterr()
-        slave_line = "[%s] creating slavegateway" % pid
-        assert slave_line in err
+        worker_line = "[%s] creating workergateway" % pid
+        assert worker_line in err
         gw.exit()
 
     def test_no_tracing_by_default(self):

--- a/testing/test_multi.py
+++ b/testing/test_multi.py
@@ -221,7 +221,7 @@ class TestGroup:
     def test_terminate_with_proxying(self):
         group = Group()
         group.makegateway("popen//id=master")
-        group.makegateway("popen//via=master//id=slave")
+        group.makegateway("popen//via=master//id=worker")
         group.terminate(1.0)
 
 

--- a/testing/test_termination.py
+++ b/testing/test_termination.py
@@ -15,7 +15,7 @@ skip_win_pypy = pytest.mark.xfail(
 )
 
 
-def test_exit_blocked_slave_execution_gateway(anypython, makegateway, pool):
+def test_exit_blocked_worker_execution_gateway(anypython, makegateway, pool):
     gateway = makegateway("popen//python=%s" % anypython)
     gateway.remote_exec(
         """


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/issues/7344.

This is *mostly* internal, with the possible exception of renaming `SlaveGateway` to `WorkerGateway`... I'm going for the optimistic change first though, it's easy to roll back to a partial fix if we need to.