### PR TITLE
waitclose in _rinfo() call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 ------------------
 
 * Dropped support for Python 3.4.
+* `#118 <https://github.com/pytest-dev/execnet/pull/118>`__: Fixed internal leak that should make
+  ``execnet`` execute remote code in the main thread more often; previously it would sometimes
+  spawn a thread to execute a ``remote_exec`` call, even when the caller
+  didn't issue multiple ``remote_exec`` calls at the same time. Some frameworks require code
+  to execute in the main thread, so the previous behavior would break them on occasion (see
+  `pytest-dev/pytest-xdist#620 <https://github.com/pytest-dev/pytest-xdist/issues/620>`__
+  for an example).
 
 
 1.7.1 (2019-08-28)

--- a/execnet/gateway.py
+++ b/execnet/gateway.py
@@ -75,7 +75,10 @@ class Gateway(gateway_base.BaseGateway):
         """ return some sys/env information from remote. """
         if update or not hasattr(self, "_cache_rinfo"):
             ch = self.remote_exec(rinfo_source)
-            self._cache_rinfo = RInfo(ch.receive())
+            try:
+                self._cache_rinfo = RInfo(ch.receive())
+            finally:
+                ch.waitclose()
         return self._cache_rinfo
 
     def hasreceiver(self):


### PR DESCRIPTION
should improve https://github.com/pytest-dev/pytest-xdist/issues/620