### PR TITLE
Stop using apipkg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+TBD (Unreleased)
+----------------
+
+* Removed the ``apipkg`` dependency.
+
 1.8.1 (2021-05-27)
 ------------------
 

--- a/execnet/__init__.py
+++ b/execnet/__init__.py
@@ -7,29 +7,45 @@ pure python lib for connecting to local and remote Python Interpreters.
 
 (c) 2012, Holger Krekel and others
 """
-import apipkg
+from ._version import version as __version__
+from .deprecated import PopenGateway
+from .deprecated import SocketGateway
+from .deprecated import SshGateway
+from .gateway_base import DataFormatError
+from .gateway_base import dump
+from .gateway_base import dumps
+from .gateway_base import load
+from .gateway_base import loads
+from .gateway_base import RemoteError
+from .gateway_base import TimeoutError
+from .gateway_bootstrap import HostNotFound
+from .multi import default_group
+from .multi import Group
+from .multi import makegateway
+from .multi import MultiChannel
+from .multi import set_execmodel
+from .rsync import RSync
+from .xspec import XSpec
 
-apipkg.initpkg(
-    __name__,
-    {
-        "__version__": "._version:version",
-        "PopenGateway": ".deprecated:PopenGateway",
-        "SocketGateway": ".deprecated:SocketGateway",
-        "SshGateway": ".deprecated:SshGateway",
-        "makegateway": ".multi:makegateway",
-        "set_execmodel": ".multi:set_execmodel",
-        "HostNotFound": ".gateway_bootstrap:HostNotFound",
-        "RemoteError": ".gateway_base:RemoteError",
-        "TimeoutError": ".gateway_base:TimeoutError",
-        "XSpec": ".xspec:XSpec",
-        "Group": ".multi:Group",
-        "MultiChannel": ".multi:MultiChannel",
-        "RSync": ".rsync:RSync",
-        "default_group": ".multi:default_group",
-        "dumps": ".gateway_base:dumps",
-        "loads": ".gateway_base:loads",
-        "load": ".gateway_base:load",
-        "dump": ".gateway_base:dump",
-        "DataFormatError": ".gateway_base:DataFormatError",
-    },
-)
+
+__all__ = [
+    "__version__",
+    "PopenGateway",
+    "SocketGateway",
+    "SshGateway",
+    "makegateway",
+    "set_execmodel",
+    "HostNotFound",
+    "RemoteError",
+    "TimeoutError",
+    "XSpec",
+    "Group",
+    "MultiChannel",
+    "RSync",
+    "default_group",
+    "dumps",
+    "loads",
+    "load",
+    "dump",
+    "DataFormatError",
+]

--- a/execnet/gateway.py
+++ b/execnet/gateway.py
@@ -11,8 +11,9 @@ import textwrap
 import types
 
 import execnet
-from execnet import gateway_base
-from execnet.gateway_base import Message
+
+from . import gateway_base
+from .gateway_base import Message
 
 importdir = os.path.dirname(os.path.dirname(execnet.__file__))
 

--- a/execnet/gateway_bootstrap.py
+++ b/execnet/gateway_bootstrap.py
@@ -6,8 +6,9 @@ import inspect
 import os
 
 import execnet
-from execnet import gateway_base
-from execnet.gateway import Gateway
+
+from . import gateway_base
+from .gateway import Gateway
 
 importdir = os.path.dirname(os.path.dirname(execnet.__file__))
 

--- a/execnet/multi.py
+++ b/execnet/multi.py
@@ -9,12 +9,12 @@ import sys
 from functools import partial
 from threading import Lock
 
-from execnet import gateway_bootstrap
-from execnet import gateway_io
-from execnet import XSpec
-from execnet.gateway_base import get_execmodel
-from execnet.gateway_base import reraise
-from execnet.gateway_base import trace
+from . import gateway_bootstrap
+from . import gateway_io
+from .gateway_base import get_execmodel
+from .gateway_base import reraise
+from .gateway_base import trace
+from .xspec import XSpec
 
 NO_ENDMARKER_WANTED = object()
 
@@ -133,7 +133,7 @@ class Group(object):
             io = gateway_io.create_io(spec, execmodel=self.execmodel)
             gw = gateway_bootstrap.bootstrap(io, spec)
         elif spec.socket:
-            from execnet import gateway_socket
+            from . import gateway_socket
 
             io = gateway_socket.create_io(spec, self, execmodel=self.execmodel)
             gw = gateway_bootstrap.bootstrap(io, spec)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ def main():
         ],
         packages=["execnet", "execnet.script"],
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
-        install_requires=["apipkg>=1.4"],
         extras_require={"testing": ["pre-commit"]},
         setup_requires=["setuptools_scm"],
     )


### PR DESCRIPTION
The advantages of apipkg AFAIU are:

- Nicer syntax. Doesn't seem very important.

- Enable lazy-loading of the sub-modules, allowing for a faster startup
  and not paying the import cost at all if not used. However execnet is
  not that big (~2000 lines) and most users will end up importing the
  big file (gateway_base.py) anyway.

- Allows absolute imports in sub-modules without worrying about
  "cannot import from partially-initialized module" errors. Doesn't seem
  very important.

So it does not seem worthwhile imposing this dependency on all users of
execnet/pytest-xdist just for that.