### PR TITLE
rsync_remote: Fix a problem when receiving a read-only directories.

### DIFF
--- a/execnet/rsync_remote.py
+++ b/execnet/rsync_remote.py
@@ -35,7 +35,11 @@ def serve_rsync(channel):
                 os.makedirs(path)
             mode = msg.pop(0)
             if mode:
-                os.chmod(path, mode)
+                # Ensure directories are writable, otherwise a
+                # permission denied error (EACCES) would be raised
+                # when attempting to receive read-only directory
+                # structures.
+                os.chmod(path, mode | 0o700)
             entrynames = {}
             for entryname in msg:
                 destpath = os.path.join(path, entryname)
@@ -59,7 +63,7 @@ def serve_rsync(channel):
                         checksum = md5(f.read()).digest()
                         f.close()
                     elif msg_mode and msg_mode != st.st_mode:
-                        os.chmod(path, msg_mode)
+                        os.chmod(path, msg_mode | 0o700)
                         return
                     else:
                         return  # already fine


### PR DESCRIPTION
When the source directories hierarchy is read-only, the read-only mode
would be preserved at the destination, preventing the directories to
be recreated by a normal user (a permission denied error, EACCES would
be raised).

* execnet/rsync_remote.py (serve_rsync.receive_directory_structure):
Bitwise OR to ensure the write bit is set on received directories.