### PR TITLE
tox should call pytest indirectly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps=
     pytest-timeout
 passenv = GITHUB_ACTIONS
 commands=
-    pytest {posargs:testing}
+    python -m pytest {posargs:testing}
 
 [testenv:docs]
 skipsdist = True


### PR DESCRIPTION
... to get better support for `tox-current-env`.