### PR TITLE
Fix CI for pytest 7.2+

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -24,7 +24,7 @@ def pytest_runtest_setup(item):
         getspecssh(item.config)  # will skip if no gx given
     yield
     if "pypy" in item.keywords and not item.config.option.pypy:
-        py.test.skip("pypy tests skipped, use --pypy to run them.")
+        pytest.skip("pypy tests skipped, use --pypy to run them.")
 
 
 @pytest.fixture
@@ -74,28 +74,26 @@ def specsocket(request):
     return getsocketspec(request.config)
 
 
-def getgspecs(config=None):
-    if config is None:
-        config = py.test.config
+def getgspecs(config):
     return map(execnet.XSpec, config.getvalueorskip("gspecs"))
 
 
-def getspecssh(config=None):
+def getspecssh(config):
     xspecs = getgspecs(config)
     for spec in xspecs:
         if spec.ssh:
             if not py.path.local.sysfind("ssh"):
-                py.test.skip("command not found: ssh")
+                pytest.skip("command not found: ssh")
             return spec
-    py.test.skip("need '--gx ssh=...'")
+    pytest.skip("need '--gx ssh=...'")
 
 
-def getsocketspec(config=None):
+def getsocketspec(config):
     xspecs = getgspecs(config)
     for spec in xspecs:
         if spec.socket:
             return spec
-    py.test.skip("need '--gx socket=...'")
+    pytest.skip("need '--gx socket=...'")
 
 
 def pytest_generate_tests(metafunc):
@@ -149,7 +147,7 @@ def anypython(request):
                 if executable.check():
                     return executable
                 executable = None
-        py.test.skip("no {} found".format(name))
+        pytest.skip("no {} found".format(name))
     if "execmodel" in request.fixturenames and name != "sys.executable":
         backend = request.getfixturevalue("execmodel").backend
         if backend != "thread":

--- a/testing/test_channel.py
+++ b/testing/test_channel.py
@@ -4,13 +4,12 @@ mostly functional tests of gateways.
 """
 import time
 
-import py
 import pytest
 from test_gateway import _find_version
 
+
 needs_early_gc = pytest.mark.skipif("not hasattr(sys, 'getrefcount')")
 needs_osdup = pytest.mark.skipif("not hasattr(os, 'dup')")
-queue = py.builtin._tryimport("queue", "Queue")
 TESTTIMEOUT = 10.0  # seconds
 
 

--- a/testing/test_gateway.py
+++ b/testing/test_gateway.py
@@ -16,7 +16,7 @@ from execnet import gateway_io
 from test_serializer import _find_version
 
 TESTTIMEOUT = 10.0  # seconds
-needs_osdup = py.test.mark.skipif("not hasattr(os, 'dup')")
+needs_osdup = pytest.mark.skipif("not hasattr(os, 'dup')")
 
 
 flakytest = pytest.mark.xfail(
@@ -36,10 +36,10 @@ def test_deprecation(recwarn, monkeypatch):
     execnet.PopenGateway().exit()
     assert recwarn.pop(DeprecationWarning)
     monkeypatch.setattr(socket, "socket", fails)
-    py.test.raises(Exception, execnet.SocketGateway, "localhost", 8811)
+    pytest.raises(Exception, execnet.SocketGateway, "localhost", 8811)
     assert recwarn.pop(DeprecationWarning)
     monkeypatch.setattr(subprocess, "Popen", fails)
-    py.test.raises(Exception, execnet.SshGateway, "not-existing")
+    pytest.raises(Exception, execnet.SshGateway, "not-existing")
     assert recwarn.pop(DeprecationWarning)
 
 
@@ -213,7 +213,7 @@ class TestBasicGateway:
     def test_remote_exec_error_after_close(self, gw):
         channel = gw.remote_exec("pass")
         channel.waitclose(TESTTIMEOUT)
-        py.test.raises(IOError, channel.send, 0)
+        pytest.raises(IOError, channel.send, 0)
 
     def test_remote_exec_no_explicit_close(self, gw):
         channel = gw.remote_exec("channel.close()")
@@ -353,7 +353,7 @@ class TestPopenGateway:
             raise SystemExit()
         """
         )
-        py.test.raises(channel.RemoteError, channel.receive)
+        pytest.raises(channel.RemoteError, channel.receive)
 
     def test_dont_write_bytecode(self, makegateway):
         check_sys_dont_write_bytecode = """
@@ -371,9 +371,9 @@ class TestPopenGateway:
         assert ret
 
 
-@py.test.mark.skipif("config.option.broken_isp")
+@pytest.mark.skipif("config.option.broken_isp")
 def test_socket_gw_host_not_found(gw, makegateway):
-    py.test.raises(execnet.HostNotFound, lambda: makegateway("socket=qwepoipqwe:9000"))
+    pytest.raises(execnet.HostNotFound, lambda: makegateway("socket=qwepoipqwe:9000"))
 
 
 class TestSshPopenGateway:
@@ -384,7 +384,7 @@ class TestSshPopenGateway:
         monkeypatch.setattr(
             gateway_io, "Popen2IOMaster", lambda *args, **kwargs: l.append(args[0])
         )
-        py.test.raises(AttributeError, lambda: makegateway("ssh=xyz//ssh_config=qwe"))
+        pytest.raises(AttributeError, lambda: makegateway("ssh=xyz//ssh_config=qwe"))
 
         assert len(l) == 1
         popen_args = l[0]
@@ -395,7 +395,7 @@ class TestSshPopenGateway:
         assert gw.remoteaddress == specssh.ssh
 
     def test_host_not_found(self, gw, makegateway):
-        py.test.raises(
+        pytest.raises(
             execnet.HostNotFound, lambda: makegateway("ssh=nowhere.codespeak.net")
         )
 
@@ -477,7 +477,7 @@ class TestTracing:
             if worker_line in line:
                 break
         else:
-            py.test.fail("did not find {!r} in tracefile".format(worker_line))
+            pytest.fail("did not find {!r} in tracefile".format(worker_line))
         gw.exit()
 
     @skip_win_pypy
@@ -498,7 +498,7 @@ class TestTracing:
 
 
 class TestStringCoerce:
-    @py.test.mark.skipif('sys.version>="3.0"')
+    @pytest.mark.skipif('sys.version>="3.0"')
     def test_2to3(self, makegateway):
         python = _find_version("3")
         gw = makegateway("popen//python=%s" % python)
@@ -515,7 +515,7 @@ class TestStringCoerce:
         assert isinstance(res, str)
         gw.exit()
 
-    @py.test.mark.skipif('sys.version<"3.0"')
+    @pytest.mark.skipif('sys.version<"3.0"')
     def test_3to2(self, makegateway):
         python = _find_version("2")
         gw = makegateway("popen//python=%s" % python)

--- a/testing/test_multi.py
+++ b/testing/test_multi.py
@@ -141,7 +141,7 @@ class TestGroup:
     def test_group_default_spec(self):
         group = Group()
         group.defaultspec = "not-existing-type"
-        py.test.raises(ValueError, group.makegateway)
+        pytest.raises(ValueError, group.makegateway)
 
     def test_group_PopenGateway(self):
         group = Group()
@@ -176,7 +176,7 @@ class TestGroup:
         assert gw.id == "hello"
         gw = group.makegateway(specs[0])
         assert gw.id == "gw0"
-        # py.test.raises(ValueError,
+        # pytest.raises(ValueError,
         #    group.allocate_id, XSpec("popen//id=hello"))
         group.terminate()
 

--- a/testing/test_rsync.py
+++ b/testing/test_rsync.py
@@ -123,7 +123,7 @@ class TestRSync:
         assert not out
         assert not err
 
-    @py.test.mark.skipif("sys.platform == 'win32' or getattr(os, '_name', '') == 'nt'")
+    @pytest.mark.skipif("sys.platform == 'win32' or getattr(os, '_name', '') == 'nt'")
     def test_permissions(self, dirs, gw1, gw2):
         source = dirs.source
         dest = dirs.dest1
@@ -230,7 +230,7 @@ class TestRSync:
         assert len(dest.listdir()) == 1
         assert len(source.listdir()) == 1
 
-    @py.test.mark.skipif("sys.version_info >= (3,)")
+    @pytest.mark.skipif("sys.version_info >= (3,)")
     def test_2_to_3_bridge_can_send_binary_files(self, tmpdir, makegateway):
         python = _find_version("3")
         gw = makegateway("popen//python=%s" % python)

--- a/testing/test_serializer.py
+++ b/testing/test_serializer.py
@@ -26,7 +26,7 @@ def _find_version(suffix=""):
                 return path
 
         else:
-            py.test.skip("can't find a {!r} executable".format(name))
+            pytest.skip("can't find a {!r} executable".format(name))
     return executable
 
 
@@ -147,7 +147,7 @@ simple_tests = [
 ]
 
 
-@py.test.mark.parametrize(["tp_name", "repr"], simple_tests)
+@pytest.mark.parametrize(["tp_name", "repr"], simple_tests)
 def test_simple(tp_name, repr, dump, load):
     if (
         sys.platform.startswith("win")

--- a/testing/test_termination.py
+++ b/testing/test_termination.py
@@ -57,7 +57,7 @@ def test_endmarker_delivery_on_remote_killterm(makegateway, execmodel):
 @skip_win_pypy
 def test_termination_on_remote_channel_receive(monkeypatch, makegateway):
     if not py.path.local.sysfind("ps"):
-        py.test.skip("need 'ps' command to externally check process status")
+        pytest.skip("need 'ps' command to externally check process status")
     monkeypatch.setenv("EXECNET_DEBUG", "2")
     gw = makegateway("popen")
     pid = gw.remote_exec("import os ; channel.send(os.getpid())").receive()

--- a/testing/test_threadpool.py
+++ b/testing/test_threadpool.py
@@ -126,7 +126,7 @@ def test_get_excinfo(pool):
         raise ValueError("42")
 
     reply = pool.spawn(f)
-    with py.test.raises(ValueError):
+    with pytest.raises(ValueError):
         reply.get(1.0)
     with pytest.raises(ValueError):
         reply.get(1.0)
@@ -145,7 +145,7 @@ def test_waitall_timeout(pool, execmodel):
     assert pool.waitall(timeout=0.1)
 
 
-@py.test.mark.skipif("not hasattr(os, 'dup')")
+@pytest.mark.skipif("not hasattr(os, 'dup')")
 def test_pool_clean_shutdown(pool):
     capture = py.io.StdCaptureFD()
     q = pool.execmodel.queue.Queue()

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py27,py37,docs,linting
 [testenv]
 deps=
     setuptools_scm
+    py
     pytest
     pytest-timeout
 passenv = GITHUB_ACTIONS

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,4 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [pytest]
 timeout = 20
 addopts = -ra
-rsyncdirs = execnet testing
 testpaths = testing


### PR DESCRIPTION
This adds an explicit dependency to `py`, and also fixes some low hanging fruits replacing `py.test` by `pytest`.

Also fixes #158.