### PR TITLE
ci: don't run on every push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,17 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+      - "test-me-*"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
+
+  pull_request:
+    branches:
+      - "master"
 
 jobs:
   tests:


### PR DESCRIPTION
Running on every push is redundant and somewhat annoying in forks.