### PR TITLE
Use utf-8 so we support non-ascii module names

### DIFF
--- a/execnet/gateway_bootstrap.py
+++ b/execnet/gateway_bootstrap.py
@@ -75,7 +75,7 @@ def bootstrap_socket(io, id):
 
 def sendexec(io, *sources):
     source = "\n".join(sources)
-    io.write((repr(source) + "\n").encode("ascii"))
+    io.write((repr(source) + "\n").encode("utf-8"))
 
 
 def fix_pid_for_jython_popen(gw):


### PR DESCRIPTION
It's safe to assume that this is always utf-8-safe because we only ever use the function to send Python source code, which must be utf-8 encodable (and indeed utf-8 at rest).  Importantly, it's _not_ relevant that the filesystem might use a non-utf8 encoding, because this directory name has already been decoded to a string and will be re-encoded from the string literal in the utf-8 source code to whatever the filesystem encoding happens to be at the other end.

Does not include tests because they'd be very painful to write, it's correct by inspection (grep `sendexec(`), and can't possibly break anything that already worked.

Fixes #153, unblocks #199.