### PR TITLE
Add readthedocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,4 +9,3 @@ python:
   install:
     - method: pip
       path: .
-

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+python:
+  install:
+    - method: pip
+      path: .
+


### PR DESCRIPTION
We need to use the configuration file to specify `pip` as the installation method; by default it uses `setuptools` via `setup.py`, which we no longer have since ported to `hatch`.

Fix #210