### PR TITLE
Bring back notice about maintenance only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ execnet: distributed Python deployment and communication
 Important
 ---------
 
+**execnet currently is in maintenance-only mode, mostly because it is still the backend
+of the pytest-xdist plugin. Do not use in new projects.**
+
 .. image:: https://img.shields.io/pypi/v/execnet.svg
     :target: https://pypi.org/project/execnet/
 

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 execnet: distributed Python deployment and communication
 ========================================================
 
-**execnet currently is in maintenance-only mode, mostly because it is still the backend
-of the pytest-xdist plugin. Do not use in new projects.**
-
 .. image:: https://img.shields.io/pypi/v/execnet.svg
     :target: https://pypi.org/project/execnet/
 

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 execnet: distributed Python deployment and communication
 ========================================================
 
-Important
----------
-
 **execnet currently is in maintenance-only mode, mostly because it is still the backend
 of the pytest-xdist plugin. Do not use in new projects.**
 


### PR DESCRIPTION
Seems this was removed by accident in https://github.com/pytest-dev/execnet/commit/e4d606f97e59d1704475652333334c327210dbbe#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168f.