### PR TITLE
multi: add timeout to reply.get

### DIFF
--- a/src/execnet/multi.py
+++ b/src/execnet/multi.py
@@ -307,7 +307,7 @@ def safe_terminate(execmodel, timeout, list_of_paired_functions):
         reply = workerpool.spawn(termkill, termfunc, killfunc)
         replylist.append(reply)
     for reply in replylist:
-        reply.get()
+        reply.get(timeout=timeout)
     workerpool.waitall(timeout=timeout)
 
 


### PR DESCRIPTION
It is possible for this call to hang, like the other calls in this function. Passing through the timeout removes that possibility.

This was first noted on #43 