### PR TITLE
Add frozen environment support

### DIFF
--- a/src/execnet/gateway.py
+++ b/src/execnet/gateway.py
@@ -194,7 +194,6 @@ def _source_of_function(function):
         args = sig.args
     if not args or args[0] != "channel":
         raise ValueError("expected first function argument to be `channel`")
-
     closure = function.__closure__
     codeobj = function.__code__
 

--- a/src/execnet/gateway_io.py
+++ b/src/execnet/gateway_io.py
@@ -58,14 +58,16 @@ def shell_split_path(path):
 
 def is_frozen_environment():
     """Check if running in a Frozen environment."""
-    return getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+
 
 def get_python_executable():
     """Get the correct Python interpreter path."""
     if is_frozen_environment():
-        return os.environ.get('PYTHON_EXECUTABLE', 'python')
+        return os.environ.get("PYTHON_EXECUTABLE", "python")
     else:
         return sys.executable
+
 
 def popen_args(spec):
     python_executable = get_python_executable()


### PR DESCRIPTION
Fixes #237 

Fixes pytest-dev/pytest-xdist#991

Adds support for frozen environments such as pyinstaller, with proper imports on the pyinstaller side this change will work, tested with pytest and pytest-xdist. 

Extra documentation available on both the mentioned issues.