### PR TITLE
Use ruff in place of black and reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,6 @@ repos:
     rev: v2.2.6
     hooks:
     -   id: codespell
--   repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-    -   id: black
 -   repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:
@@ -23,11 +19,13 @@ repos:
     hooks:
     -   id: pyupgrade
         args:  [--py37-plus]
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.14
     hooks:
-    -   id: reorder-python-imports
-        args: ['--application-directories=execnet', --py37-plus]
+      - id: ruff
+        args: [ --fix ]
+        exclude: "^doc/"
+      - id: ruff-format
 -   repo: https://github.com/PyCQA/doc8
     rev: 'v1.1.1'
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ testing = [
 [project.urls]
 Homepage = "https://execnet.readthedocs.io/en/latest/"
 
+[tool.ruff.lint]
+ignore = ["E741"]
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ Homepage = "https://execnet.readthedocs.io/en/latest/"
 [tool.ruff.lint]
 ignore = ["E741"]
 
+[tool.ruff.lint.isort]
+case-sensitive = true
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/src/execnet/gateway_base.py
+++ b/src/execnet/gateway_base.py
@@ -596,7 +596,7 @@ class GatewayReceivedTerminate(Exception):
 
 def geterrortext(excinfo, format_exception=traceback.format_exception, sysex=sysex):
     try:
-        l = format_exception(*excinfo)
+        l = format_exception(*excinfo)  # noqa:E741
         errortext = "".join(l)
     except sysex:
         raise
@@ -633,6 +633,7 @@ NO_ENDMARKER_WANTED = object()
 
 class Channel:
     "Communication channel between two Python Interpreter execution points."
+
     RemoteError = RemoteError
     TimeoutError = TimeoutError
     _INTERNALWAKEUP = 1000
@@ -1543,7 +1544,7 @@ class _Serializer:
     def save_int(self, i):
         self._save_integral(i, opcode.INT, opcode.LONGINT)
 
-    def save_long(self, l):
+    def save_long(self, l):  # noqa:E741
         self._save_integral(l, opcode.LONG, opcode.LONGLONG)
 
     def save_float(self, flt):

--- a/src/execnet/gateway_io.py
+++ b/src/execnet/gateway_io.py
@@ -3,7 +3,6 @@ execnet io initialization code
 
 creates io instances used for gateway io
 """
-import os
 import shlex
 import sys
 
@@ -228,4 +227,4 @@ def serve_proxy_io(proxy_channelX):
 
 
 if __name__ == "__channelexec__":
-    serve_proxy_io(channel)  # type: ignore[name-defined]
+    serve_proxy_io(channel)  # type: ignore[name-defined] # noqa:F821

--- a/src/execnet/rsync_remote.py
+++ b/src/execnet/rsync_remote.py
@@ -114,4 +114,4 @@ def serve_rsync(channel):
 
 
 if __name__ == "__channelexec__":
-    serve_rsync(channel)  # type: ignore[name-defined]
+    serve_rsync(channel)  # type: ignore[name-defined]  # noqa:F821

--- a/src/execnet/script/shell.py
+++ b/src/execnet/script/shell.py
@@ -26,7 +26,7 @@ def clientside():
         while 1:
             r, w, e = select.select(inputlist, [], [])
             if sys.stdin in r:
-                line = raw_input()
+                line = raw_input()  # noqa:F821
                 sock.sendall(line + "\n")
             if sock in r:
                 line = sock.recv(4096)

--- a/testing/test_threadpool.py
+++ b/testing/test_threadpool.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pytest
 from execnet.gateway_base import WorkerPool
@@ -61,7 +60,7 @@ def test_running_semnatics(pool, execmodel):
 
 
 def test_waitfinish_on_reply(pool):
-    l = []
+    l = []  # noqa:E741
     reply = pool.spawn(lambda: l.append(1))
     reply.waitfinish()
     assert l == [1]


### PR DESCRIPTION
Unfortunately black and reorder-python-imports are no longer compatible between each other:

https://github.com/asottile/reorder-python-imports/issues/367
https://github.com/asottile/reorder-python-imports/issues/366
https://github.com/psf/black/issues/4175

Take this opportunity to try out ruff.

Closes #231.