### PR TITLE
Fix ruff isort configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,11 @@ Homepage = "https://execnet.readthedocs.io/en/latest/"
 
 [tool.ruff.lint]
 ignore = ["E741"]
+extend-select = ["I001"]
 
 [tool.ruff.lint.isort]
-case-sensitive = true
+force-single-line = true
+known-third-party = ["src"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/execnet/__init__.py
+++ b/src/execnet/__init__.py
@@ -8,21 +8,20 @@ pure python lib for connecting to local and remote Python Interpreters.
 """
 from ._version import version as __version__
 from .gateway_base import DataFormatError
+from .gateway_base import RemoteError
+from .gateway_base import TimeoutError
 from .gateway_base import dump
 from .gateway_base import dumps
 from .gateway_base import load
 from .gateway_base import loads
-from .gateway_base import RemoteError
-from .gateway_base import TimeoutError
 from .gateway_bootstrap import HostNotFound
-from .multi import default_group
 from .multi import Group
-from .multi import makegateway
 from .multi import MultiChannel
+from .multi import default_group
+from .multi import makegateway
 from .multi import set_execmodel
 from .rsync import RSync
 from .xspec import XSpec
-
 
 __all__ = [
     "__version__",

--- a/src/execnet/gateway.py
+++ b/src/execnet/gateway.py
@@ -153,8 +153,8 @@ RemoteStatus = RInfo
 
 
 def rinfo_source(channel):
-    import sys
     import os
+    import sys
 
     channel.send(
         dict(

--- a/src/execnet/gateway_base.py
+++ b/src/execnet/gateway_base.py
@@ -425,8 +425,8 @@ if DEBUG == "2":
             pass  # nothing we can do, likely interpreter-shutdown
 
 elif DEBUG:
-    import tempfile
     import os
+    import tempfile
 
     fn = os.path.join(tempfile.gettempdir(), "execnet-debug-%d" % pid)
     # sys.stderr.write("execnet-debug at %r" % (fn,))

--- a/src/execnet/gateway_io.py
+++ b/src/execnet/gateway_io.py
@@ -7,9 +7,11 @@ import shlex
 import sys
 
 try:
-    from execnet.gateway_base import Popen2IO, Message
+    from execnet.gateway_base import Message
+    from execnet.gateway_base import Popen2IO
 except ImportError:
-    from __main__ import Popen2IO, Message  # type: ignore[no-redef]
+    from __main__ import Message  # type: ignore[no-redef]
+    from __main__ import Popen2IO  # type: ignore[no-redef]
 
 from functools import partial
 

--- a/src/execnet/multi.py
+++ b/src/execnet/multi.py
@@ -10,9 +10,9 @@ from threading import Lock
 
 from . import gateway_bootstrap
 from . import gateway_io
+from .gateway_base import WorkerPool
 from .gateway_base import get_execmodel
 from .gateway_base import trace
-from .gateway_base import WorkerPool
 from .xspec import XSpec
 
 NO_ENDMARKER_WANTED = object()

--- a/src/execnet/rsync_remote.py
+++ b/src/execnet/rsync_remote.py
@@ -5,8 +5,8 @@
 
 def serve_rsync(channel):
     import os
-    import stat
     import shutil
+    import stat
     from hashlib import md5
 
     destdir, options = channel.receive()

--- a/src/execnet/script/quitserver.py
+++ b/src/execnet/script/quitserver.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import socket
 import sys
 
-
 host, port = sys.argv[1].split(":")
 hostport = (host, int(port))
 

--- a/src/execnet/script/socketserverservice.py
+++ b/src/execnet/script/socketserverservice.py
@@ -15,7 +15,6 @@ import win32evtlogutil
 import win32service
 import win32serviceutil
 
-
 appname = "ExecNetSocketServer"
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -6,8 +6,8 @@ from typing import Iterator
 
 import execnet
 import pytest
-from execnet.gateway_base import get_execmodel
 from execnet.gateway_base import WorkerPool
+from execnet.gateway_base import get_execmodel
 
 collect_ignore = ["build", "doc/_build"]
 

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -19,7 +19,6 @@ from execnet.gateway_base import ChannelFactory
 from execnet.gateway_base import Message
 from execnet.gateway_base import Popen2IO
 
-
 skip_win_pypy = pytest.mark.xfail(
     condition=hasattr(sys, "pypy_version_info") and sys.platform.startswith("win"),
     reason="failing on Windows on PyPy (#63)",

--- a/testing/test_channel.py
+++ b/testing/test_channel.py
@@ -5,7 +5,6 @@ import time
 
 import pytest
 
-
 needs_early_gc = pytest.mark.skipif("not hasattr(sys, 'getrefcount')")
 needs_osdup = pytest.mark.skipif("not hasattr(os, 'dup')")
 TESTTIMEOUT = 10.0  # seconds

--- a/testing/test_serializer.py
+++ b/testing/test_serializer.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import execnet
 import pytest
 
-
 # We use the execnet folder in order to avoid triggering a missing apipkg.
 pyimportdir = os.fspath(Path(execnet.__file__).parent)
 


### PR DESCRIPTION
As brought up in https://github.com/pytest-dev/execnet/pull/239#issuecomment-1917570146, the isort settings for ruff were not being applied.