### PR TITLE
Avoid using sys.exc_info

### DIFF
--- a/src/execnet/gateway.py
+++ b/src/execnet/gateway.py
@@ -5,7 +5,6 @@ gateway code for initiating popen, socket and ssh connections.
 import inspect
 import linecache
 import os
-import sys
 import textwrap
 import types
 
@@ -56,10 +55,9 @@ class Gateway(gateway_base.BaseGateway):
             self._send(Message.GATEWAY_TERMINATE)
             self._trace("--> io.close_write")
             self._io.close_write()
-        except (ValueError, EOFError, OSError):
-            v = sys.exc_info()[1]
+        except (ValueError, EOFError, OSError) as exc:
             self._trace("io-error: could not send termination sequence")
-            self._trace(" exception: %r" % v)
+            self._trace(" exception: %r" % exc)
 
     def reconfigure(self, py2str_as_py3str=True, py3str_as_py2str=False):
         """

--- a/src/execnet/gateway_base.py
+++ b/src/execnet/gateway_base.py
@@ -283,7 +283,7 @@ class Reply:
         try:
             return self._result
         except AttributeError:
-            raise self._excinfo[1].with_traceback(self._excinfo[2])
+            raise self._exc
 
     def waitfinish(self, timeout=None):
         if not self._result_ready.wait(timeout):
@@ -294,10 +294,8 @@ class Reply:
         try:
             try:
                 self._result = func(*args, **kwargs)
-            except BaseException:
-                # sys may be already None when shutting down the interpreter
-                if sys is not None:
-                    self._excinfo = sys.exc_info()
+            except BaseException as exc:
+                self._exc = exc
         finally:
             self._result_ready.set()
             self.running = False
@@ -437,10 +435,9 @@ elif DEBUG:
             line = " ".join(map(str, msg))
             debugfile.write(line + "\n")
             debugfile.flush()
-        except Exception:
+        except Exception as exc:
             try:
-                v = sys.exc_info()[1]
-                sys.stderr.write(f"[{pid}] exception during tracing: {v!r}\n")
+                sys.stderr.write(f"[{pid}] exception during tracing: {exc!r}\n")
             except Exception:
                 pass  # nothing we can do, likely interpreter-shutdown
 
@@ -507,8 +504,7 @@ class Message:
             header = io.read(9)  # type 1, channel 4, payload 4
             if not header:
                 raise EOFError("empty read")
-        except EOFError:
-            e = sys.exc_info()[1]
+        except EOFError as e:
             raise EOFError("couldn't load message header, " + e.args[0])
         msgtype, channel, payload = struct.unpack("!bii", header)
         return Message(msgtype, channel, io.read(payload))
@@ -594,14 +590,20 @@ class GatewayReceivedTerminate(Exception):
     """Receiverthread got termination message."""
 
 
-def geterrortext(excinfo, format_exception=traceback.format_exception, sysex=sysex):
+def geterrortext(
+    exc: BaseException,
+    format_exception=traceback.format_exception,
+    sysex=sysex,
+) -> str:
     try:
-        l = format_exception(*excinfo)  # noqa:E741
+        # In py310, can change this to:
+        # l = format_exception(exc)
+        l = format_exception(type(exc), exc, exc.__traceback__)
         errortext = "".join(l)
     except sysex:
         raise
     except BaseException:
-        errortext = f"{excinfo[0].__name__}: {excinfo[1]}"
+        errortext = f"{type(exc).__name__}: {exc}"
     return errortext
 
 
@@ -937,10 +939,9 @@ class ChannelFactory:
             try:
                 data = loads_internal(data, channel, strconfig)
                 callback(data)  # even if channel may be already closed
-            except Exception:
-                excinfo = sys.exc_info()
-                self.gateway._trace("exception during callback: %s" % excinfo[1])
-                errortext = self.gateway._geterrortext(excinfo)
+            except Exception as exc:
+                self.gateway._trace("exception during callback: %s" % exc)
+                errortext = self.gateway._geterrortext(exc)
                 self.gateway._send(
                     Message.CHANNEL_CLOSE_ERROR, id, dumps_internal(errortext)
                 )
@@ -1017,7 +1018,6 @@ class ChannelFileRead(ChannelFile):
 
 
 class BaseGateway:
-    exc_info = sys.exc_info
     _sysex = sysex
     id = "<worker>"
 
@@ -1054,11 +1054,11 @@ class BaseGateway:
                     del msg
         except (KeyboardInterrupt, GatewayReceivedTerminate):
             pass
-        except EOFError:
+        except EOFError as exc:
             log("EOF without prior gateway termination message")
-            self._error = self.exc_info()[1]
-        except Exception:
-            log(self._geterrortext(self.exc_info()))
+            self._error = exc
+        except Exception as exc:
+            log(self._geterrortext(exc))
         log("finishing receiving thread")
         # wake up and terminate any execution waiting to receive
         self._channelfactory._finished_receiving()
@@ -1079,8 +1079,7 @@ class BaseGateway:
         try:
             message.to_io(self._io)
             self._trace("sent", message)
-        except (OSError, ValueError):
-            e = sys.exc_info()[1]
+        except (OSError, ValueError) as e:
             self._trace("failed to send", message, e)
             # ValueError might be because the IO is already closed
             raise OSError("cannot send (already closed?)")
@@ -1166,12 +1165,11 @@ class WorkerGateway(BaseGateway):
         except KeyboardInterrupt:
             channel.close(INTERRUPT_TEXT)
             raise
-        except BaseException:
-            excinfo = self.exc_info()
-            if not isinstance(excinfo[1], EOFError):
+        except BaseException as exc:
+            if not isinstance(exc, EOFError):
                 if not channel.gateway._channelfactory.finished:
-                    self._trace(f"got exception: {excinfo[1]!r}")
-                    errortext = self._geterrortext(excinfo)
+                    self._trace(f"got exception: {exc!r}")
+                    errortext = self._geterrortext(exc)
                     channel.close(errortext)
                     return
             self._trace("ignoring EOFError because receiving finished")

--- a/src/execnet/gateway_socket.py
+++ b/src/execnet/gateway_socket.py
@@ -84,6 +84,6 @@ def create_io(spec, group, execmodel):
     io.remoteaddress = "%s:%d" % (host, port)
     try:
         sock.connect((host, port))
-    except execmodel.socket.gaierror:
-        raise HostNotFound(str(sys.exc_info()[1]))
+    except execmodel.socket.gaierror as e:
+        raise HostNotFound() from e
     return io

--- a/src/execnet/multi.py
+++ b/src/execnet/multi.py
@@ -4,7 +4,6 @@ Managing Gateway Groups and interactions with multiple channels.
 (c) 2008-2014, Holger Krekel and others
 """
 import atexit
-import sys
 from functools import partial
 from threading import Lock
 
@@ -285,11 +284,11 @@ class MultiChannel:
         for ch in self._channels:
             try:
                 ch.waitclose()
-            except ch.RemoteError:
+            except ch.RemoteError as exc:
                 if first is None:
-                    first = sys.exc_info()
+                    first = exc
         if first:
-            raise first[1].with_traceback(first[2])
+            raise first
 
 
 def safe_terminate(execmodel, timeout, list_of_paired_functions):

--- a/src/execnet/script/socketserver.py
+++ b/src/execnet/script/socketserver.py
@@ -94,14 +94,13 @@ def startserver(serversock, loop=False):
                 exec_from_one_connection(serversock)
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except BaseException:
+            except BaseException as exc:
                 if debug:
                     import traceback
 
                     traceback.print_exc()
                 else:
-                    excinfo = sys.exc_info()
-                    print_("got exception", excinfo[1])
+                    print_("got exception", exc)
             os.chdir(execute_path)
             if not loop:
                 break

--- a/testing/test_basics.py
+++ b/testing/test_basics.py
@@ -229,16 +229,14 @@ def test_geterrortext(checker):
     out = checker.run_check(
         inspect.getsource(gateway_base)
         + """
-class Arg:
+class Arg(Exception):
     pass
-errortext = geterrortext((Arg, "1", 4))
+errortext = geterrortext(Arg())
 assert "Arg" in errortext
-import sys
 try:
     raise ValueError("17")
-except ValueError:
-    excinfo = sys.exc_info()
-    s = geterrortext(excinfo)
+except ValueError as exc:
+    s = geterrortext(exc)
     assert "17" in s
     print ("all passed")
     """


### PR DESCRIPTION
In Python 3 it's better to handle exception objects directly, they now carry their traceback.