### PR TITLE
gateway_base: fix `load(strconfig)` getting ignored

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+TBD
+---
+
+* `#267 <https://github.com/pytest-dev/execnet/issue/267>`__ Fixed regression
+  in 2.1.0 where the ``strconfig`` argument to ``load``/``loads`` is ignored.
+
 2.1.0 (2024-04-05)
 ------------------
 

--- a/src/execnet/gateway_base.py
+++ b/src/execnet/gateway_base.py
@@ -1391,9 +1391,7 @@ class Unserializer:
             gw: BaseGateway | None = channel_or_gateway.gateway
         else:
             gw = channel_or_gateway
-        if channel_or_gateway is None:
-            strconfig = None
-        else:
+        if channel_or_gateway is not None:
             strconfig = channel_or_gateway._strconfig
         if strconfig:
             self.py2str_as_py3str, self.py3str_as_py2str = strconfig

--- a/testing/test_serializer.py
+++ b/testing/test_serializer.py
@@ -163,3 +163,8 @@ def test_tuple_nested_with_empty_in_between(dump, load) -> None:
     tp, s = load(p)
     assert tp == "tuple"
     assert s == "(1, (), 3)"
+
+
+def test_py2_string_loads() -> None:
+    """Regression test for #267."""
+    assert execnet.loads(b"\x02M\x00\x00\x00\x01aQ") == b"a"


### PR DESCRIPTION
Accidental regression in 2.1.0 (c58d485ff97d401dd02516cce).

Fix #267.

Thanks to @RonnyPfannschmidt for tracking down the buggy line.