### PR TITLE
gateway: Test concurrent rinfo for main_thread_only

### DIFF
--- a/testing/test_gateway.py
+++ b/testing/test_gateway.py
@@ -669,13 +669,11 @@ def test_concurrent_rinfo(execmodel: gateway_base.ExecModel) -> None:
             assert hasattr(gw, "_cache_rinfo")
 
         ch = gw.remote_exec(
-            """
+            f"""
                 import os, time
                 time.sleep({sleep_time})
                 channel.send(os.getpid())
-        """.format(
-                sleep_time=sleep_time
-            )
+        """
         )
         rinfo = gw._rinfo()
         try:


### PR DESCRIPTION
Add test coverage for a bug triggered by pytest-cov when it tried to call _rinfo after the gateway was already busy with a remote_exec call:

https://github.com/pytest-dev/pytest-xdist/issues/1071