### PR TITLE
💅 Add a config for the Chronographer GitHub App

### DIFF
--- a/.github/chronographer.yml
+++ b/.github/chronographer.yml
@@ -1,0 +1,20 @@
+---
+
+branch-protection-check-name: Changelog entry
+action-hints:
+  check-title-prefix: "Chronographer: "
+  external-docs-url: >-
+    https://docs.pytest.org/en/latest/contributing.html#preparing-pull-requests
+  inline-markdown: >-
+    See
+    https://docs.pytest.org/en/latest/contributing.html#preparing-pull-requests
+    for details.
+enforce-name:
+  suffix: .rst
+exclude:
+  humans:
+  - pyup-bot
+labels:
+  skip-changelog: skip news
+
+...


### PR DESCRIPTION
This app allows requiring changelog fragments to be included with each pull request.

A new `skip news` label is expected to be created in the repo to match the configuration.