### PR TITLE
💅 Add a config for the Patchback GitHub App

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,7 @@
+---
+
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: 'backport '  # IMPORTANT: the labels are space-delimited
+# target_branch_prefix: ''  # The project's backport branches are non-prefixed
+
+...


### PR DESCRIPTION
This patch prepares the project's backporting process to start being handled by the Patchback GitHub App [[1]].

It is expected that a new label like `backport 2.1.x` is created to match the configuration.

[1]: https://github.com/apps/patchback