### PR TITLE
ci: group Dependabot uv and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns: ["*"]
+      python-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Add a `uv` ecosystem entry so lockfile updates are managed as version updates.
- Group all `github-actions` updates and `uv` version/security updates into fewer PRs.

## Context
Dependabot currently opens a separate PR for each uv dependency and for individual GitHub Actions bumps. Grouping matches other pytest-dev repos (e.g. pytest-xdist) and keeps the review queue manageable after the uv.lock adoption.

## Test plan
- [ ] Confirm Dependabot accepts the config after merge
- [ ] Close or leave the existing ungrouped Dependabot PRs; next run should open grouped ones instead
- [ ] Verify future weekly runs produce grouped uv / GitHub Actions PRs


Made with [Cursor](https://cursor.com)