### PR TITLE
docs/ci: follow default-branch rename to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,12 @@ name: test
 on:
   push:
     branches:
-      - "master"
+      - "main"
       - "test-me-*"
 
   pull_request:
     branches:
-      - "master"
+      - "main"
 
 # Cancel running jobs for the same workflow and branch.
 concurrency:

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -7,7 +7,7 @@ This document describes the steps to make a new ``execnet`` release.
 Version
 -------
 
-``master`` should always be green and a potential release candidate. ``execnet`` follows
+``main`` should always be green and a potential release candidate. ``execnet`` follows
 semantic versioning, so given that the current version is ``X.Y.Z``, to find the next version number
 one needs to look at the ``CHANGELOG.rst`` file:
 
@@ -22,7 +22,7 @@ Steps
 
 To publish a new release ``X.Y.Z``, the steps are as follows:
 
-#. Create a new branch named ``release-X.Y.Z`` from the latest ``master``.
+#. Create a new branch named ``release-X.Y.Z`` from the latest ``main``.
 
 #. Update the ``CHANGELOG.rst`` file with the new release information.
 
@@ -30,4 +30,4 @@ To publish a new release ``X.Y.Z``, the steps are as follows:
 
 #. Once the PR is **green** and **approved**, start the ``deploy`` workflow manually from the branch ``release-VERSION``, passing ``VERSION`` as parameter.
 
-#. Merge the release PR to ``master``.
+#. Merge the release PR to ``main``.

--- a/doc/example/test_info.rst
+++ b/doc/example/test_info.rst
@@ -172,7 +172,7 @@ sends back the results.
 Instantiate gateways through sockets
 -----------------------------------------------------
 
-.. _`socketserver.py`: https://raw.githubusercontent.com/pytest-dev/execnet/master/execnet/script/socketserver.py
+.. _`socketserver.py`: https://raw.githubusercontent.com/pytest-dev/execnet/main/src/execnet/script/socketserver.py
 
 In cases where you do not have SSH-access to a machine
 you need to download a small version-independent standalone


### PR DESCRIPTION
## Summary
- Point CI `push`/`pull_request` triggers at `main` after the default-branch rename
- Update `RELEASING.rst` branch references from `master` to `main`
- Fix the docs raw GitHub link for `socketserver.py` to `main` and the current `src/` path

Closes #420

## Test plan
- [ ] Confirm CI runs on this PR against `main`
- [ ] Spot-check that domain uses of “master” (proxy gateway id) were left untouched
- [ ] On Read the Docs: set project Default branch to `main` if still `master` (project setting is stale; `latest` already builds from `main`)


Made with [Cursor](https://cursor.com)