### PR TITLE
fix: expose ChannelFile encoding

### DIFF
--- a/src/execnet/gateway_base.py
+++ b/src/execnet/gateway_base.py
@@ -1062,6 +1062,8 @@ class ChannelFactory:
 
 
 class ChannelFile:
+    encoding = "utf-8"
+
     def __init__(self, channel: Channel, proxyclose: bool = True) -> None:
         self.channel = channel
         self._proxyclose = proxyclose

--- a/testing/test_channel.py
+++ b/testing/test_channel.py
@@ -308,6 +308,11 @@ class TestChannelBasicBehaviour:
 
 
 class TestChannelFile:
+    def test_channel_file_encoding(self, gw: Gateway) -> None:
+        channel = gw.newchannel()
+        assert channel.makefile("r").encoding == "utf-8"
+        assert channel.makefile("w").encoding == "utf-8"
+
     def test_channel_file_write(self, gw: Gateway) -> None:
         channel = gw.remote_exec(
             """


### PR DESCRIPTION
## Summary

- expose the UTF-8 encoding on execnet channel file wrappers
- define the attribute once on the shared `ChannelFile` base
- cover both public `Channel.makefile()` modes with a regression test

This prevents text-stream consumers from raising `AttributeError` when an
execnet channel file replaces `sys.stdout`.

## Verification

- real popen gateway reproduction with remote `sys.stdout` replacement
- `uv run pytest -q testing/test_channel.py`
- 279 passed, 217 skipped

Fixes #161

Implementation and review were assisted by OpenAI Codex. I reproduced the
failure and verified the final behavior and test suite locally.
